### PR TITLE
cc-genpro1.2.py

### DIFF
--- a/cc-genpro1.2.py
+++ b/cc-genpro1.2.py
@@ -24,7 +24,7 @@ print ("\033[1;33m8.\033[1;31mSalir...!!\033[0m")
 print (30 * '-')
  
 ## Get input ###
-choice = raw_input('\033[1;33mingresa tu opcion: \033[0m')
+choice = input('\033[1;33mingresa tu opcion: \033[0m')
  
 ### Convert string to int type ##
 choice = int(choice)


### PR DESCRIPTION
This is a correction to the code, i runed the program appear this error: Traceback (most recent call last):
  File "/opt/ccgenprors/./cc-genpro1.2.py", line 27, in <module>
    choice = raw_input('\033[1;33mingresa tu opcion: \033[0m')
NameError: name 'raw_input' is not defined
With phyon3, the tag raw_input is remplace for "input" so i replaced the tag "raw_input" for tag "input" and run the program and problem is solved